### PR TITLE
Add gdb `u` command mapping to windbg `pa`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ GDB Command  | WinDBG Command  | Description
 `n/ni` | `t`  |  Step into
 `finish` |  `pt`  | Step to next return |
 None |  `pc`  | Step to next call |
-None | `pa`  | Step to address  |  
+`u` | `pa`  | Step to address  |  
 
 ## Variables, Symbols, and Memory
 


### PR DESCRIPTION
Add gdb `u` command to map it to windbg `pa`. `u` won't trace every executed instruction but at least when coming from gdb you can easily find the corresponding command to windbg.